### PR TITLE
Changes node constructor to be more robust at start up

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "wirelesstags": "^0.5.3"
+    "wirelesstags": "^0.6.0"
   },
   "devDependencies": {
     "jshint": "^2.9.4"


### PR DESCRIPTION
There is a potential for a race condition at start up due to the asynchronous nature of connecting the platform object, and determining whether it is connected. As a result, an API call to determine connection status may execute, and result in false, at the same time as the connect() call is about to succeed, and as a consequence sometimes some nodes never receive the 'connect' event. We protect against this now by checking whether the platform is in the process of connecting.

This depends on the v0.6.0 release of [wirelesstags](https://www.npmjs.com/package/wirelesstags), which is pending. 