### PR TITLE
Fixes bug causing config selectors to fail populating due to 401

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-wirelesstag",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node-RED node for Wireless Tags (http://wirelesstag.net)",
   "main": "./wirelesstag.js",
   "scripts": {
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "wirelesstags": "^0.5.3"
+    "wirelesstags": "^0.5.6"
   },
   "devDependencies": {
     "jshint": "^2.9.4"

--- a/wirelesstag.html
+++ b/wirelesstag.html
@@ -32,7 +32,7 @@
             return "Wireless Tag";
         },
         oneditprepare: function() {
-            var mountpoint = "/wirelesstag";
+            var mountpoint = "wirelesstag";
             var prefix;
             var node = this;
 


### PR DESCRIPTION
It turns out that the access token only gets automatically added to the jquery AJAX request if the URL is relative, i.e., does not start with a leading slash.