### PR TITLE
Adds new sensor properties from wirelesstags to message payload

### DIFF
--- a/wirelesstag.html
+++ b/wirelesstag.html
@@ -264,7 +264,10 @@
         properties <code>sensor</code> (the kind of sensor, such as light),
         <code>reading</code> (the sensor's current reading),
         <code>eventState</code> (the current state, such
-        as <em>Normal</em>, <em>Too High</em>, etc),
+        as <em>Normal</em>, <em>Too High</em>, etc), <code>probeType</code>
+        (the type of probe for certain sensors such as temperature),
+        <code>probeDisconnected</code> (whether an external probe is disconnected
+        for sensors that allow detecting that),
         and <code>armed</code> (true if the sensor is armed and false otherwise).</li>
         <li><strong><code>msg.sensorConfig</code></strong>: the
         properties of the monitoring configuration for the

--- a/wirelesstag.js
+++ b/wirelesstag.js
@@ -195,6 +195,8 @@ module.exports = function(RED) {
                 sensor: sensor.sensorType,
                 reading: sensor.reading,
                 eventState: sensor.eventState,
+                probeType: sensor.probeType,
+                probeDisconnected: sensor.probeDisconnected,
                 armed: sensor.isArmed()
             }
         };


### PR DESCRIPTION
Specifically, the 0.7.x series adds `sensor.probeType` and `sensor.probeDisconnected` for certain types of sensors (temp, humidity, moisture; and temp, respectively).

Note that because `sensor.probeDisconnected` is currently only supported by a single tag model (the "Basic" model of the Outdoor series), its value will be undefined for most cases, and therefore it will not be included in the message payload. (This is a feature of Node-RED.)