### PR TITLE
 Makes cloud signon/signoff handling more modular and resilient

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node-RED node for Wireless Tags (http://wirelesstag.net)",
   "main": "./wirelesstag.js",
   "scripts": {
-    "test": "tape test/[0-9]*.js",
+    "test": "TEST_ALL=1 tape test/[0-9]*.js",
     "test:ci": "tape test/01*.js | faucet",
     "lint": "eslint --ext .html,.js",
     "pretest": "npm run lint -- ."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-wirelesstag",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Node-RED node for Wireless Tags (http://wirelesstag.net)",
   "main": "./wirelesstag.js",
   "scripts": {

--- a/test/01_load-create-run.js
+++ b/test/01_load-create-run.js
@@ -61,20 +61,11 @@ test('our nodes are registered', function(t) {
 test('our nodes can be created and added to a flow', function(t) {
     t.plan(9);
 
-    NODE_TYPES.forEach((nt) => {
-        let conf = { id: RED.util.generateId(), type: nt };
-        if (nt === CONFIG_NODE) {
-            conf.credentials = {
-                username: '$(WIRELESSTAG_API_USER)',
-                password: '$(WIRELESSTAG_API_PASSWORD)'
-            };
-        } else {
-            conf.x = conf.y = 0;
-            conf.cloud = nodes[CONFIG_NODE].id;
-            conf.wires = [];
-        }
-        nodes[nt] = conf;
-    });
+    nodes[CONFIG_NODE] = fixture.createNodeDescriptor(RED, CONFIG_NODE);
+    for (let nt of NODE_TYPES) {
+        if (nt === CONFIG_NODE) continue;
+        nodes[nt] = fixture.createNodeDescriptor(RED, nt, nodes[CONFIG_NODE].id);
+    }
     let flow = {
         label: "Test Flow",
         nodes: [nodes[SENSOR_NODE], nodes[ALL_NODE]],

--- a/test/01_load-create-run.js
+++ b/test/01_load-create-run.js
@@ -59,7 +59,7 @@ test('our nodes are registered', function(t) {
 });
 
 test('our nodes can be created and added to a flow', function(t) {
-    t.plan(9);
+    t.plan(11);
 
     nodes[CONFIG_NODE] = fixture.createNodeDescriptor(RED, CONFIG_NODE);
     for (let nt of NODE_TYPES) {
@@ -85,6 +85,8 @@ test('our nodes can be created and added to a flow', function(t) {
         nodes[result.configs[0].type] = result.configs[0];
 
         for (let i = 0; i < result.nodes.length; i++) {
+            t.equal(result.nodes[i].id, nodes[result.nodes[i].type].id,
+                    `node ${i} has correct ID`);
             nodes[result.nodes[i].type] = result.nodes[i];
             t.equal(result.nodes[i].cloud,
                     result.configs[0].id,
@@ -169,6 +171,7 @@ test('connects to cloud and starts IO for our nodes', function(t) {
             t.ok(sendSpies[nt].notCalled, 'send() not called for ' + nt);
         });
         platform.discoverTags().then((tags) => {
+            tags = tags.filter((tag) => tag.isPhysicalTag());
             t.ok(tags.length > 0, 'have one or more tags to test');
             let tag = tags[0];
             let sensorNode = nodes[SENSOR_NODE];

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -51,6 +51,20 @@ module.exports = {
             console.error(e.stack ? e.stack : e);
         });
     },
+    createNodeDescriptor: function(RED, nodeType, confNodeId) {
+        let conf = { id: RED.util.generateId(), type: nodeType };
+        if (confNodeId) {
+            conf.x = conf.y = 0;
+            conf.cloud = confNodeId;
+            conf.wires = [];
+        } else {
+            conf.credentials = {
+                username: '$(WIRELESSTAG_API_USER)',
+                password: '$(WIRELESSTAG_API_PASSWORD)'
+            };
+        }
+        return conf;
+    },
     setup: function() {
         let RED = require('node-red');
 

--- a/wirelesstag.js
+++ b/wirelesstag.js
@@ -166,12 +166,13 @@ module.exports = function(RED) {
         let node = this;
         let config = node.config;
         let dataHandler = sendData.bind(node);
+        node.log(`registering ${tag.name} for updates`);
         tag.on('data', dataHandler);
         if (config.autoUpdate) {
             let tagUpdater = RED.nodes.getNode(config.cloud).tagUpdater;
             tagUpdater.addTags(tag);
             node.once('close', () => {
-                node.log("stopping updates");
+                node.log(`stopping updates for ${tag.name}`);
                 tagUpdater.removeTags(tag);
                 tag.removeListener('data', dataHandler);
             });


### PR DESCRIPTION
This includes catching the situation that the platform transitioned to signed off-state passively, because a parallel thread expired the authentication token. Also includes distinguishing between what needs to happen only once on the first signon, and what needs to happen on every signon/signoff cycle.

Closes #14.